### PR TITLE
Fixed file find in case-insensitive systems

### DIFF
--- a/src/Interceptor.php
+++ b/src/Interceptor.php
@@ -534,14 +534,15 @@ class Interceptor {
             if (strpos($namespace, $prefix) === 0) {
                 foreach ($dirs as $dir) {
                     $path = $dir . DIRECTORY_SEPARATOR . substr($logicalPath, strlen($prefix));
-                    if (is_dir($path)) {
-                        return $path;
-                    }
+
                     if (file_exists($file = $path . '.php')) {
                         return $file ;
                     }
                     if (file_exists($file = $path . '.hh')) {
                         return $file;
+                    }
+                    if (is_dir($path)) {
+                        return $path;
                     }
                 }
             }


### PR DESCRIPTION
In case-insensitive systems we MUST first check file and then try to check a directory.

It's a bug if we have a folder `\some\our\plugin\` and a file `\some\our\Plugin.php`. In case-insensitive systems folder will be loaded instead of file
